### PR TITLE
chore: update client, types, and toolset to align with frozen trade simulator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ import {
   SpecificChain,
   PriceHistoryParams,
   TradeHistoryParams,
-  TradeParams
+  TradeParams,
+  TeamMetadata,
 } from "./types.js";
 
 // Create an MCP server instance using the Server class
@@ -37,6 +38,75 @@ const server = new Server(
 // Define the MCP tools
 const TRADING_SIM_TOOLS: Tool[] = [
   // Account Tools
+  {
+    name: "get_profile",
+    description: "Get your team's profile information",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+      $schema: "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    name: "update_profile",
+    description: "Update your team's profile information",
+    inputSchema: {
+      type: "object",
+      properties: {
+        contactPerson: {
+          type: "string",
+          description: "New contact person name"
+        },
+        metadata: {
+          type: "object",
+          description: "Agent metadata with ref, description, and social information",
+          properties: {
+            ref: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                  description: "Agent name"
+                },
+                version: {
+                  type: "string",
+                  description: "Agent version"
+                },
+                url: {
+                  type: "string",
+                  description: "Link to agent documentation or repository"
+                }
+              }
+            },
+            description: {
+              type: "string",
+              description: "Brief description of the agent"
+            },
+            social: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                  description: "Agent social name"
+                },
+                email: {
+                  type: "string",
+                  description: "Contact email for the agent"
+                },
+                twitter: {
+                  type: "string",
+                  description: "Twitter handle"
+                }
+              }
+            }
+          }
+        }
+      },
+      additionalProperties: false,
+      $schema: "http://json-schema.org/draft-07/schema#"
+    }
+  },
   {
     name: "get_balances",
     description: "Get token balances for your team",
@@ -65,7 +135,7 @@ const TRADING_SIM_TOOLS: Tool[] = [
       properties: {
         limit: {
           type: "number",
-          description: "Maximum number of trades to return"
+          description: "Maximum number of trades to retrieve (default: 20)"
         },
         offset: {
           type: "number",
@@ -182,28 +252,52 @@ const TRADING_SIM_TOOLS: Tool[] = [
   // Trading Tools
   {
     name: "execute_trade",
-    description: "Execute a trade between two tokens",
+    description: "Execute a trade between tokens",
     inputSchema: {
       type: "object",
       properties: {
         fromToken: {
-          type: "string",
+          type: "string", 
           description: "Source token address"
         },
         toToken: {
-          type: "string",
+          type: "string", 
           description: "Destination token address"
         },
         amount: {
-          type: "string",
+          type: "string", 
           description: "Amount of fromToken to trade"
+        },
+        reason: {
+          type: "string",
+          description: "Reason for executing this trade"
         },
         slippageTolerance: {
           type: "string",
           description: "Optional slippage tolerance percentage (e.g., '0.5' for 0.5%)"
+        },
+        fromChain: {
+          type: "string",
+          enum: ["svm", "evm"],
+          description: "Optional blockchain type for source token"
+        },
+        toChain: {
+          type: "string",
+          enum: ["svm", "evm"],
+          description: "Optional blockchain type for destination token"
+        },
+        fromSpecificChain: {
+          type: "string",
+          enum: ["eth", "polygon", "bsc", "arbitrum", "base", "optimism", "avalanche", "linea", "svm"],
+          description: "Optional specific chain for source token"
+        },
+        toSpecificChain: {
+          type: "string",
+          enum: ["eth", "polygon", "bsc", "arbitrum", "base", "optimism", "avalanche", "linea", "svm"],
+          description: "Optional specific chain for destination token"
         }
       },
-      required: ["fromToken", "toToken", "amount"],
+      required: ["fromToken", "toToken", "amount", "reason"],
       additionalProperties: false,
       $schema: "http://json-schema.org/draft-07/schema#"
     }
@@ -225,6 +319,26 @@ const TRADING_SIM_TOOLS: Tool[] = [
         amount: {
           type: "string",
           description: "Amount of fromToken to potentially trade"
+        },
+        fromChain: {
+          type: "string",
+          enum: ["svm", "evm"],
+          description: "Optional blockchain type for source token"
+        },
+        toChain: {
+          type: "string",
+          enum: ["svm", "evm"],
+          description: "Optional blockchain type for destination token"
+        },
+        fromSpecificChain: {
+          type: "string",
+          enum: ["eth", "polygon", "bsc", "arbitrum", "base", "optimism", "avalanche", "linea", "svm"],
+          description: "Optional specific chain for source token"
+        },
+        toSpecificChain: {
+          type: "string",
+          enum: ["eth", "polygon", "bsc", "arbitrum", "base", "optimism", "avalanche", "linea", "svm"],
+          description: "Optional specific chain for destination token"
         }
       },
       required: ["fromToken", "toToken", "amount"],
@@ -249,6 +363,43 @@ const TRADING_SIM_TOOLS: Tool[] = [
     description: "Get the competition leaderboard",
     inputSchema: {
       type: "object",
+      properties: {
+        competitionId: {
+          type: "string",
+          description: "Optional competition ID (if not provided, the active competition is used)"
+        }
+      },
+      additionalProperties: false,
+      $schema: "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    name: "get_competition_rules",
+    description: "Get the rules and configuration details for the competition",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+      $schema: "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  
+  // Health Tools
+  {
+    name: "get_health",
+    description: "Basic health check for the trading simulator API",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+      $schema: "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    name: "get_detailed_health",
+    description: "Detailed health check with information about all services",
+    inputSchema: {
+      type: "object",
       properties: {},
       additionalProperties: false,
       $schema: "http://json-schema.org/draft-07/schema#"
@@ -256,308 +407,276 @@ const TRADING_SIM_TOOLS: Tool[] = [
   }
 ];
 
-// Register tool handlers
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: TRADING_SIM_TOOLS
-}));
+// Set up request handlers
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: TRADING_SIM_TOOLS
+  };
+});
+
+server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  return {
+    resources: []
+  };
+});
+
+server.setRequestHandler(ListPromptsRequestSchema, async () => {
+  return {
+    prompts: []
+  };
+});
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  try {
-    const { name, arguments: args } = request.params;
+  const { name, arguments: args = {} } = request.params;
+  logger.info(`Handling tool call: ${name}`);
 
+  try {
+    // Handle different tools
     switch (name) {
       // Account Tools
+      case "get_profile": {
+        const response = await tradingClient.getProfile();
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
+      }
+      
+      case "update_profile": {
+        if (!args || typeof args !== "object") {
+          throw new Error("Invalid arguments for update_profile");
+        }
+        
+        const contactPerson = "contactPerson" in args ? args.contactPerson as string : undefined;
+        const metadata = "metadata" in args ? args.metadata as TeamMetadata : undefined;
+        
+        const response = await tradingClient.updateProfile(contactPerson, metadata);
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
+      }
+        
       case "get_balances": {
-        try {
-          const response = await tradingClient.getBalances();
-          
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(response, null, 2),
-              },
-            ],
-            isError: false,
-          };
-        } catch (error: any) {
-          logger.error('Error in get_balances:', error);
-          throw error;
-        }
+        const response = await tradingClient.getBalances();
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
       }
-
+      
       case "get_portfolio": {
-        try {
-          const response = await tradingClient.getPortfolio();
-          
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(response, null, 2),
-              },
-            ],
-            isError: false,
-          };
-        } catch (error: any) {
-          logger.error('Error in get_portfolio:', error);
-          throw error;
-        }
+        const response = await tradingClient.getPortfolio();
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
       }
-
+      
       case "get_trades": {
         if (!args || typeof args !== "object") {
           throw new Error("Invalid arguments for get_trades");
         }
         
-        try {
-          const params: TradeHistoryParams = {};
-          
-          if ('limit' in args) params.limit = args.limit as number;
-          if ('offset' in args) params.offset = args.offset as number;
-          if ('token' in args) params.token = args.token as string;
-          if ('chain' in args) params.chain = args.chain as BlockchainType;
-          
-          const response = await tradingClient.getTrades(params);
-          
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(response, null, 2),
-              },
-            ],
-            isError: false,
-          };
-        } catch (error: any) {
-          logger.error('Error in get_trades:', error);
-          throw error;
-        }
+        const tradeParams: TradeHistoryParams = {};
+        if ("limit" in args) tradeParams.limit = args.limit as number;
+        if ("offset" in args) tradeParams.offset = args.offset as number;
+        if ("token" in args) tradeParams.token = args.token as string;
+        if ("chain" in args) tradeParams.chain = args.chain as BlockchainType;
+        
+        const response = await tradingClient.getTradeHistory(tradeParams);
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
       }
-
+      
       // Price Tools
       case "get_price": {
         if (!args || typeof args !== "object" || !("token" in args)) {
           throw new Error("Invalid arguments for get_price");
         }
         
-        try {
-          const token = args.token as string;
-          const chain = args.chain as BlockchainType | undefined;
-          const specificChain = args.specificChain as SpecificChain | undefined;
-          
-          const response = await tradingClient.getPrice(token, chain, specificChain);
-          
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(response, null, 2),
-              },
-            ],
-            isError: false,
-          };
-        } catch (error: any) {
-          logger.error('Error in get_price:', error);
-          throw error;
-        }
+        const token = args.token as string;
+        const chain = "chain" in args ? args.chain as BlockchainType : undefined;
+        const specificChain = "specificChain" in args ? args.specificChain as SpecificChain : undefined;
+        
+        const response = await tradingClient.getPrice(token, chain, specificChain);
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
       }
-
+      
       case "get_token_info": {
         if (!args || typeof args !== "object" || !("token" in args)) {
           throw new Error("Invalid arguments for get_token_info");
         }
         
-        try {
-          const token = args.token as string;
-          const chain = args.chain as BlockchainType | undefined;
-          const specificChain = args.specificChain as SpecificChain | undefined;
-          
-          const response = await tradingClient.getTokenInfo(token, chain, specificChain);
-          
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(response, null, 2),
-              },
-            ],
-            isError: false,
-          };
-        } catch (error: any) {
-          logger.error('Error in get_token_info:', error);
-          throw error;
-        }
+        const token = args.token as string;
+        const chain = "chain" in args ? args.chain as BlockchainType : undefined;
+        const specificChain = "specificChain" in args ? args.specificChain as SpecificChain : undefined;
+        
+        const response = await tradingClient.getTokenInfo(token, chain, specificChain);
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
       }
-
+      
       case "get_price_history": {
         if (!args || typeof args !== "object" || !("token" in args)) {
           throw new Error("Invalid arguments for get_price_history");
         }
         
-        try {
-          const params: PriceHistoryParams = {
-            token: args.token as string
-          };
-          
-          if ('startTime' in args) params.startTime = args.startTime as string;
-          if ('endTime' in args) params.endTime = args.endTime as string;
-          if ('interval' in args) params.interval = args.interval as '1m' | '5m' | '15m' | '1h' | '4h' | '1d';
-          if ('chain' in args) params.chain = args.chain as BlockchainType;
-          if ('specificChain' in args) params.specificChain = args.specificChain as SpecificChain;
-          
-          const response = await tradingClient.getPriceHistory(params);
-          
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(response, null, 2),
-              },
-            ],
-            isError: false,
-          };
-        } catch (error: any) {
-          logger.error('Error in get_price_history:', error);
-          throw error;
-        }
+        const historyParams: PriceHistoryParams = {
+          token: args.token as string
+        };
+        
+        if ("startTime" in args) historyParams.startTime = args.startTime as string;
+        if ("endTime" in args) historyParams.endTime = args.endTime as string;
+        if ("interval" in args) historyParams.interval = args.interval as PriceHistoryParams['interval'];
+        if ("chain" in args) historyParams.chain = args.chain as BlockchainType;
+        if ("specificChain" in args) historyParams.specificChain = args.specificChain as SpecificChain;
+        
+        const response = await tradingClient.getPriceHistory(historyParams);
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
       }
-
+      
       // Trading Tools
       case "execute_trade": {
-        if (!args || typeof args !== "object" || !("fromToken" in args) || !("toToken" in args) || !("amount" in args)) {
+        if (!args || typeof args !== "object" || 
+            !("fromToken" in args) || !("toToken" in args) || 
+            !("amount" in args) || !("reason" in args)) {
           throw new Error("Invalid arguments for execute_trade");
         }
         
-        try {
-          const params: TradeParams = {
-            fromToken: args.fromToken as string,
-            toToken: args.toToken as string,
-            amount: args.amount as string
-          };
-          
-          if ('slippageTolerance' in args) params.slippageTolerance = args.slippageTolerance as string;
-          
-          // Determine chains automatically from token addresses
-          params.fromChain = tradingClient.detectChain(params.fromToken);
-          params.toChain = tradingClient.detectChain(params.toToken);
-          
-          const response = await tradingClient.executeTrade(params);
-          
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(response, null, 2),
-              },
-            ],
-            isError: false,
-          };
-        } catch (error: any) {
-          logger.error('Error in execute_trade:', error);
-          throw error;
-        }
+        const tradeExecParams: TradeParams = {
+          fromToken: args.fromToken as string,
+          toToken: args.toToken as string,
+          amount: args.amount as string,
+          reason: args.reason as string
+        };
+        
+        if ("slippageTolerance" in args) tradeExecParams.slippageTolerance = args.slippageTolerance as string;
+        if ("fromChain" in args) tradeExecParams.fromChain = args.fromChain as BlockchainType;
+        if ("toChain" in args) tradeExecParams.toChain = args.toChain as BlockchainType;
+        if ("fromSpecificChain" in args) tradeExecParams.fromSpecificChain = args.fromSpecificChain as SpecificChain;
+        if ("toSpecificChain" in args) tradeExecParams.toSpecificChain = args.toSpecificChain as SpecificChain;
+        
+        const response = await tradingClient.executeTrade(tradeExecParams);
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
       }
-
+      
       case "get_quote": {
-        if (!args || typeof args !== "object" || !("fromToken" in args) || !("toToken" in args) || !("amount" in args)) {
+        if (!args || typeof args !== "object" || 
+            !("fromToken" in args) || !("toToken" in args) || !("amount" in args)) {
           throw new Error("Invalid arguments for get_quote");
         }
         
-        try {
-          const fromToken = args.fromToken as string;
-          const toToken = args.toToken as string;
-          const amount = args.amount as string;
-          
-          const response = await tradingClient.getQuote(fromToken, toToken, amount);
-          
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(response, null, 2),
-              },
-            ],
-            isError: false,
-          };
-        } catch (error: any) {
-          logger.error('Error in get_quote:', error);
-          throw error;
-        }
+        const fromToken = args.fromToken as string;
+        const toToken = args.toToken as string;
+        const amount = args.amount as string;
+        const fromChain = "fromChain" in args ? args.fromChain as BlockchainType : undefined;
+        const toChain = "toChain" in args ? args.toChain as BlockchainType : undefined;
+        const fromSpecificChain = "fromSpecificChain" in args ? args.fromSpecificChain as SpecificChain : undefined;
+        const toSpecificChain = "toSpecificChain" in args ? args.toSpecificChain as SpecificChain : undefined;
+        
+        const response = await tradingClient.getQuote(
+          fromToken, 
+          toToken, 
+          amount, 
+          fromChain, 
+          toChain, 
+          fromSpecificChain, 
+          toSpecificChain
+        );
+        
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
       }
-
+      
       // Competition Tools
       case "get_competition_status": {
-        try {
-          const response = await tradingClient.getCompetitionStatus();
-          
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(response, null, 2),
-              },
-            ],
-            isError: false,
-          };
-        } catch (error: any) {
-          logger.error('Error in get_competition_status:', error);
-          throw error;
-        }
+        const response = await tradingClient.getCompetitionStatus();
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
       }
-
+      
       case "get_leaderboard": {
-        try {
-          const response = await tradingClient.getLeaderboard();
-          
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(response, null, 2),
-              },
-            ],
-            isError: false,
-          };
-        } catch (error: any) {
-          logger.error('Error in get_leaderboard:', error);
-          throw error;
-        }
+        const competitionId = "competitionId" in args ? args.competitionId as string : undefined;
+        const response = await tradingClient.getLeaderboard(competitionId);
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
       }
-
+      
+      case "get_competition_rules": {
+        const response = await tradingClient.getRules();
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+        };
+      }
+        
+      // Health Tools
+      case "get_health": {
+        const response = await tradingClient.getHealthStatus();
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
+      }
+        
+      case "get_detailed_health": {
+        const response = await tradingClient.getDetailedHealthStatus();
+        return {
+          content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+          isError: false
+        };
+      }
+      
       default:
         return {
           content: [{ type: "text", text: `Unknown tool: ${name}` }],
-          isError: true,
+          isError: true
         };
     }
   } catch (error) {
+    logger.error(`Error handling tool call ${name}:`, error);
     return {
-      content: [
-        {
-          type: "text",
-          text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-        },
-      ],
-      isError: true,
+      content: [{ 
+        type: "text", 
+        text: `Error: ${error instanceof Error ? error.message : String(error)}` 
+      }],
+      isError: true
     };
   }
 });
 
-// Add support for resources/list and prompts/list methods
-server.setRequestHandler(ListResourcesRequestSchema, async () => {
-  return { resources: [] };
-});
-
-server.setRequestHandler(ListPromptsRequestSchema, async () => {
-  return { prompts: [] };
-});
-
-// Start the server using stdio transport
 async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  logger.info("Trading Simulator MCP Server running on stdio");
+  try {
+    // Create a transport for stdio
+    const transport = new StdioServerTransport();
+
+    // Connect the server to the transport
+    await server.connect(transport);
+    logger.info("Trading Simulator MCP server started");
+  } catch (error) {
+    logger.error("Failed to start server:", error);
+    process.exit(1);
+  }
 }
 
-main().catch(logger.error); 
+// Run the main function
+main().catch(console.error); 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,19 @@ export enum SpecificChain {
   SVM = 'svm'
 }
 
+// Portfolio source
+export enum PortfolioSource {
+  SNAPSHOT = 'snapshot',
+  LIVE_CALCULATION = 'live-calculation'
+}
+
+// Competition status
+export enum CompetitionStatus {
+  PENDING = 'PENDING',
+  ACTIVE = 'ACTIVE',
+  COMPLETED = 'COMPLETED'
+}
+
 // Common token addresses
 export const COMMON_TOKENS = {
   // Solana tokens
@@ -39,12 +52,27 @@ export const COMMON_TOKENS = {
   }
 };
 
+// Team metadata structure
+export interface TeamMetadata {
+  ref?: {
+    name?: string;
+    version?: string;
+    url?: string;
+  };
+  description?: string;
+  social?: {
+    name?: string;
+    email?: string;
+    twitter?: string;
+  };
+}
+
 // Trade Parameters
 export interface TradeParams {
   fromToken: string;
   toToken: string;
   amount: string;
-  price?: string;
+  reason: string;
   slippageTolerance?: string;
   fromChain?: BlockchainType;
   toChain?: BlockchainType;
@@ -73,38 +101,65 @@ export interface PriceHistoryParams {
 // API Response Types
 export interface ApiResponse {
   success: boolean;
+  message?: string;
   error?: {
     code: string;
     message: string;
   };
 }
 
+// Error Response Type
+export interface ErrorResponse {
+  success: false;
+  error: string;
+  status: number;
+}
+
+// Team profile response
+export interface TeamProfileResponse extends ApiResponse {
+  team: {
+    id: string;
+    name: string;
+    email: string;
+    contactPerson: string;
+    metadata?: TeamMetadata;
+    createdAt: string;
+    updatedAt: string;
+  };
+}
+
+// Token balance type
+export interface TokenBalance {
+  token: string;
+  amount: number;
+  chain: BlockchainType;
+  specificChain: SpecificChain | null;
+}
+
 export interface BalancesResponse extends ApiResponse {
   teamId: string;
-  balances: Array<{
-    token: string;
-    amount: number;
-    chain: BlockchainType;
-    specificChain: string | null;
-  }>;
+  balances: TokenBalance[];
+}
+
+// Token portfolio item
+export interface TokenPortfolioItem {
+  token: string;
+  amount: number;
+  price: number;
+  value: number;
+  chain: BlockchainType;
+  specificChain: SpecificChain | null;
 }
 
 export interface PortfolioResponse extends ApiResponse {
   teamId: string;
   totalValue: number;
-  tokens: Array<{
-    token: string;
-    amount: number;
-    price: number;
-    value: number;
-    chain: BlockchainType;
-    specificChain: string | null;
-  }>;
+  tokens: TokenPortfolioItem[];
   snapshotTime: string;
-  source: 'snapshot' | 'live-calculation';
+  source: PortfolioSource;
 }
 
-export interface TradeResponse {
+export interface TradeTransaction {
   id: string;
   teamId: string;
   competitionId: string;
@@ -114,17 +169,24 @@ export interface TradeResponse {
   toAmount: number;
   price: number;
   success: boolean;
-  error: string | null;
+  error?: string;
+  reason: string;
   timestamp: string;
-  fromChain: BlockchainType;
-  toChain: BlockchainType;
+  fromChain: string;
+  toChain: string;
   fromSpecificChain: string | null;
   toSpecificChain: string | null;
 }
 
-export interface TradesResponse extends ApiResponse {
+// Standardize on TradeHistoryResponse for consistency with api-types.ts
+export interface TradeHistoryResponse extends ApiResponse {
   teamId: string;
-  trades: TradeResponse[];
+  trades: TradeTransaction[];
+}
+
+// Standardize on TradeResponse for consistency with api-types.ts
+export interface TradeResponse extends ApiResponse {
+  transaction: TradeTransaction;
 }
 
 export interface PriceResponse extends ApiResponse {
@@ -132,44 +194,35 @@ export interface PriceResponse extends ApiResponse {
   token: string;
   chain: BlockchainType;
   specificChain: string | null;
+  timestamp?: string;
 }
 
 export interface TokenInfoResponse extends ApiResponse {
-  price: number | null;
   token: string;
   chain: BlockchainType;
-  specificChain: string | null;
+  specificChain: SpecificChain | null;
   name?: string;
   symbol?: string;
   decimals?: number;
+  logoURI?: string;
+  price?: number;
+  priceChange24h?: number;
+  volume24h?: number;
+  marketCap?: number;
+}
+
+// Price history point
+export interface PriceHistoryPoint {
+  timestamp: string;
+  price: number;
 }
 
 export interface PriceHistoryResponse extends ApiResponse {
-  priceHistory: Array<{
-    token: string;
-    usdPrice: number;
-    timestamp: string;
-    chain: BlockchainType;
-  }>;
-}
-
-export interface TradeExecutionResponse extends ApiResponse {
-  transaction: {
-    id: string;
-    teamId: string;
-    competitionId: string;
-    fromToken: string;
-    toToken: string;
-    fromAmount: number;
-    toAmount: number;
-    price: number;
-    success: boolean;
-    timestamp: string;
-    fromChain: BlockchainType;
-    toChain: BlockchainType;
-    fromSpecificChain: string | null;
-    toSpecificChain: string | null;
-  };
+  token: string;
+  chain: BlockchainType;
+  specificChain: SpecificChain | null;
+  interval: string;
+  history: PriceHistoryPoint[];
 }
 
 export interface QuoteResponse extends ApiResponse {
@@ -187,53 +240,98 @@ export interface QuoteResponse extends ApiResponse {
     fromChain: BlockchainType;
     toChain: BlockchainType;
   };
+  fromSpecificChain?: string;
+  toSpecificChain?: string;
+}
+
+// Competition details
+export interface Competition {
+  id: string;
+  name: string;
+  description: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  status: CompetitionStatus;
+  allowCrossChainTrading: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Leaderboard entry
+export interface LeaderboardEntry {
+  rank: number;
+  teamId: string;
+  teamName: string;
+  portfolioValue: number;
+  active: boolean;
+  deactivationReason?: string;
 }
 
 export interface CompetitionStatusResponse extends ApiResponse {
   active: boolean;
-  competition: {
-    id: string;
-    name: string;
-    description: string | null;
-    startDate: string;
-    endDate: string | null;
-    status: string;
-    createdAt: string;
-    updatedAt: string;
-  } | null;
+  competition: Competition | null;
   message?: string;
+  participating?: boolean;
 }
 
 export interface LeaderboardResponse extends ApiResponse {
-  competition: {
-    id: string;
-    name: string;
-    description: string | null;
-    startDate: string;
-    endDate: string | null;
-    status: string;
-    createdAt: string;
-    updatedAt: string;
-  };
-  leaderboard: Array<{
-    rank: number;
-    teamId: string;
-    teamName: string;
-    portfolioValue: number;
-  }>;
+  competition: Competition;
+  leaderboard: LeaderboardEntry[];
+  hasInactiveTeams?: boolean;
 }
 
 export interface CompetitionRulesResponse extends ApiResponse {
   rules: {
     tradingRules: string[];
-    supportedChains: string[];
-    rateLimits: string[] | {
-      tradeRequestsPerMinute: number;
-      priceRequestsPerMinute: number;
-      accountRequestsPerMinute: number;
-      totalRequestsPerMinute: number;
-      totalRequestsPerHour: number;
+    rateLimits: string[];
+    availableChains: {
+      svm: boolean;
+      evm: string[];
     };
     slippageFormula: string;
+    portfolioSnapshots: {
+      interval: string;
+    };
   };
-} 
+}
+
+// Health check response
+export interface HealthCheckResponse extends ApiResponse {
+  status: "ok" | "error";
+  version?: string;
+  uptime?: number;
+  timestamp: string;
+  services?: {
+    database?: {
+      status: "ok" | "error";
+      message?: string;
+    };
+    cache?: {
+      status: "ok" | "error";
+      message?: string;
+    };
+    priceProviders?: {
+      status: "ok" | "error";
+      providers?: {
+        name: string;
+        status: "ok" | "error";
+        message?: string;
+      }[];
+    };
+  };
+}
+
+// Detailed health check response
+export interface DetailedHealthCheckResponse extends ApiResponse {
+  status: "ok" | "error";
+  timestamp: string;
+  uptime: number;
+  version: string;
+  services: {
+    priceTracker: string;
+    balanceManager: string;
+    tradeSimulator: string;
+    competitionManager: string;
+    teamManager: string;
+  };
+}


### PR DESCRIPTION
# Summary

- Current trading simulator running at `https://api.competitions.recall.network/` is using a version of the trading simulator API (https://github.com/recallnet/trading-simulator) at commit `c86317b767b2bc41283f7c760c9c74bfd43f95b0`
- This PR brings the API types and client methods and request/response conventions up-to-date with the api-client used in the e2e tests in the trading simulator at the commit mentioned above
- Finally, this updates the toolset to reflect the new added methods or changed existing methods